### PR TITLE
feat: Vision AI analysis per pin (issue #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ pinterest-export https://www.pinterest.com/username/boardname --output-dir ./my-
 # Also download all images
 pinterest-export https://www.pinterest.com/username/boardname --cache-images
 
+# Add Gemini Vision analysis per pin
+pinterest-export https://www.pinterest.com/username/boardname --vision
+
+# Increase Gemini analysis parallelism
+pinterest-export https://www.pinterest.com/username/boardname --vision --vision-concurrency 10
+
 # Scrape only (no files written)
 pinterest-export https://www.pinterest.com/username/boardname --no-export
 
@@ -80,19 +86,27 @@ LLM-optimised Markdown — ready to paste into Claude, GPT, or any AI tool as co
 ### Cached images
 When `--cache-images` is set, all pin images are downloaded to a local cache directory and referenced by their Pinterest image ID. Subsequent exports reuse cached images.
 
+### Vision metadata
+When `--vision` is enabled (with `GEMINI_API_KEY` or `GOOGLE_API_KEY` set), each pin is enriched with:
+- `vision_description`
+- `vision_tags`
+- `vision_colors`
+- `vision_style`
+- `vision_mood`
+
 ## Features
 
 - Scrapes public Pinterest boards via Playwright (handles infinite scroll)
 - Rich live progress UI: real-time pin count + image download progress bar
 - JSON export with full structured metadata
 - Markdown export optimised for LLM context windows
+- Optional Gemini Flash (`gemini-2.0-flash`) analysis per pin
 - Local image cache with concurrent downloads
 - `--limit` flag for controlled scrapes
 - `--no-export` flag for dry runs / in-memory use
 
 ## Roadmap
 
-- [#5](https://github.com/brtdwchtr/pinterest-export/issues/5) Vision AI analysis (per-pin descriptions, tags, themes)
 - [#6](https://github.com/brtdwchtr/pinterest-export/issues/6) Theme clustering across boards
 - [#7](https://github.com/brtdwchtr/pinterest-export/issues/7) HTML gallery generator
 - [#11](https://github.com/brtdwchtr/pinterest-export/issues/11) Config file support (`.pinterest-export.toml`)

--- a/pinterest_export/cli.py
+++ b/pinterest_export/cli.py
@@ -1,6 +1,7 @@
 """CLI entry point for pinterest-export."""
 
 import asyncio
+import os
 from pathlib import Path
 
 import click
@@ -25,6 +26,7 @@ from pinterest_export.exporter import export_json, export_markdown
 from pinterest_export.image_cache import download_pins
 from pinterest_export.scraper import scrape_board_sync
 from pinterest_export.url_parser import parse_board_url
+from pinterest_export.vision import analyze_pins
 
 console = Console()
 
@@ -60,7 +62,28 @@ def _make_scrape_status(pin_count: int, label: str = "Scraping board…") -> Tex
     default=False,
     help="Skip JSON/Markdown export — just scrape and display a summary.",
 )
-def main(url: str, limit: int | None, output_dir: str | None, cache_images: bool, no_export: bool):
+@click.option(
+    "--vision",
+    is_flag=True,
+    default=False,
+    help="Analyze each pin image with Gemini Vision and enrich exports.",
+)
+@click.option(
+    "--vision-concurrency",
+    default=5,
+    type=int,
+    show_default=True,
+    help="Max parallel Gemini Vision analyses when --vision is enabled.",
+)
+def main(
+    url: str,
+    limit: int | None,
+    output_dir: str | None,
+    cache_images: bool,
+    no_export: bool,
+    vision: bool,
+    vision_concurrency: int,
+):
     """Scrape a Pinterest board and export pin data.
 
     URL is the Pinterest board URL (e.g. https://www.pinterest.com/user/boardname/).
@@ -70,6 +93,9 @@ def main(url: str, limit: int | None, output_dir: str | None, cache_images: bool
     """
     if limit is not None and limit <= 0:
         console.print("[red]Error:[/red] --limit must be a positive integer.")
+        raise SystemExit(1)
+    if vision_concurrency <= 0:
+        console.print("[red]Error:[/red] --vision-concurrency must be a positive integer.")
         raise SystemExit(1)
 
     # ── Parse URL ────────────────────────────────────────────────────────────
@@ -105,6 +131,38 @@ def main(url: str, limit: int | None, output_dir: str | None, cache_images: bool
     if not pins:
         console.print("[yellow]No pins found — check the URL and try again.[/yellow]")
         raise SystemExit(0)
+
+    # ── Vision analysis (optional) ───────────────────────────────────────────
+    analyzed_count = 0
+    if vision:
+        api_key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        if not api_key:
+            console.print(
+                "[red]Error:[/red] --vision requires GEMINI_API_KEY "
+                "(or GOOGLE_API_KEY) to be set."
+            )
+            raise SystemExit(1)
+
+        with console.status(f"🔍 Analyzing {len(pins)} pins with Gemini Vision..."):
+            asyncio.run(analyze_pins(pins, api_key=api_key, concurrency=vision_concurrency))
+
+        analyzed_count = sum(
+            1
+            for pin in pins
+            if any(
+                [
+                    pin.extra.get("vision_description"),
+                    pin.extra.get("vision_tags"),
+                    pin.extra.get("vision_colors"),
+                    pin.extra.get("vision_style"),
+                    pin.extra.get("vision_mood"),
+                ]
+            )
+        )
+        console.print(
+            f"[bold green]✓[/bold green] Vision metadata added for "
+            f"[bold]{analyzed_count}[/bold] / {len(pins)} pins.\n"
+        )
 
     # ── Download images (optional) ────────────────────────────────────────────
     image_paths: dict[str, Path] = {}
@@ -180,6 +238,8 @@ def main(url: str, limit: int | None, output_dir: str | None, cache_images: bool
 
     table.add_row("Board", board_slug)
     table.add_row("Pins scraped", str(len(pins)))
+    if vision:
+        table.add_row("Vision analyzed", f"{analyzed_count}/{len(pins)}")
 
     if cache_images:
         table.add_row("Images cached", str(len(image_paths)))

--- a/pinterest_export/exporter.py
+++ b/pinterest_export/exporter.py
@@ -78,6 +78,26 @@ def export_markdown(
         lines.append(f"- **Image URL:** {pin.image_url}")
         if image_paths and pin.id in image_paths:
             lines.append(f"- **Local image:** {image_paths[pin.id]}")
+
+        vision_description = pin.extra.get("vision_description")
+        if vision_description:
+            lines.append(f"- **Vision description:** {vision_description}")
+
+        vision_tags = pin.extra.get("vision_tags")
+        if isinstance(vision_tags, list) and vision_tags:
+            lines.append(f"- **Vision tags:** {', '.join(str(tag) for tag in vision_tags)}")
+
+        vision_colors = pin.extra.get("vision_colors")
+        if isinstance(vision_colors, list) and vision_colors:
+            lines.append(f"- **Vision colors:** {', '.join(str(color) for color in vision_colors)}")
+
+        vision_style = pin.extra.get("vision_style")
+        if isinstance(vision_style, list) and vision_style:
+            lines.append(f"- **Vision style:** {', '.join(str(style) for style in vision_style)}")
+
+        vision_mood = pin.extra.get("vision_mood")
+        if vision_mood:
+            lines.append(f"- **Vision mood:** {vision_mood}")
         lines.append("")
 
     output_path.parent.mkdir(parents=True, exist_ok=True)

--- a/pinterest_export/vision.py
+++ b/pinterest_export/vision.py
@@ -1,0 +1,177 @@
+"""Vision analysis for Pinterest pins using Gemini Flash."""
+
+import asyncio
+import json
+import logging
+import re
+from typing import Any
+
+import httpx
+
+from pinterest_export.models import Pin
+
+try:
+    import google.generativeai as genai
+except ImportError:  # pragma: no cover - exercised when dependency is unavailable
+    genai = None
+
+logger = logging.getLogger(__name__)
+
+_VISION_PROMPT = """Analyze this Pinterest image and return only valid JSON.
+
+Required JSON schema:
+{
+  "description": "short visual description",
+  "tags": ["5 to 10 concise tags"],
+  "dominant_colors": ["hex colors like #AABBCC"],
+  "style_keywords": ["style terms"],
+  "mood": "single mood word or short phrase"
+}
+
+Rules:
+- Return JSON only (no markdown, no prose, no code fences).
+- Keep tags and style_keywords concise and lowercase where natural.
+- dominant_colors must be hex values prefixed with #.
+"""
+
+
+def _response_text(response: Any) -> str:
+    """Extract text from a Gemini response object."""
+    try:
+        text = response.text or ""
+        if text:
+            return text
+    except Exception:
+        pass
+
+    chunks: list[str] = []
+    for candidate in getattr(response, "candidates", []) or []:
+        content = getattr(candidate, "content", None)
+        parts = getattr(content, "parts", []) if content else []
+        for part in parts:
+            value = getattr(part, "text", None)
+            if value:
+                chunks.append(value)
+    return "\n".join(chunks).strip()
+
+
+def _extract_json(text: str) -> dict[str, Any]:
+    """Parse JSON from a Gemini response string."""
+    cleaned = text.strip()
+
+    if cleaned.startswith("```"):
+        cleaned = re.sub(r"^```(?:json)?\s*", "", cleaned, flags=re.IGNORECASE)
+        cleaned = re.sub(r"\s*```$", "", cleaned)
+
+    try:
+        parsed = json.loads(cleaned)
+        return parsed if isinstance(parsed, dict) else {}
+    except json.JSONDecodeError:
+        pass
+
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return {}
+
+    snippet = cleaned[start : end + 1]
+    try:
+        parsed = json.loads(snippet)
+        return parsed if isinstance(parsed, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _string_list(value: Any) -> list[str]:
+    """Normalize an arbitrary value to a list of non-empty strings."""
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _normalize_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Gemini JSON payload to expected keys and types."""
+    return {
+        "description": str(payload.get("description", "")).strip(),
+        "tags": _string_list(payload.get("tags")),
+        "dominant_colors": _string_list(payload.get("dominant_colors")),
+        "style_keywords": _string_list(payload.get("style_keywords")),
+        "mood": str(payload.get("mood", "")).strip(),
+    }
+
+
+async def analyze_pin(pin: Pin, api_key: str) -> dict:
+    """Analyze a single pin image with Gemini Flash and return parsed JSON metadata."""
+    if not api_key:
+        logger.warning("Skipping vision analysis for pin %s: missing API key", pin.id)
+        return {}
+
+    if not pin.image_url:
+        logger.warning("Skipping vision analysis for pin %s: missing image URL", pin.id)
+        return {}
+
+    if genai is None:
+        logger.warning("Skipping vision analysis for pin %s: google-generativeai is not installed", pin.id)
+        return {}
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Referer": "https://www.pinterest.com/",
+    }
+
+    try:
+        async with httpx.AsyncClient(headers=headers, follow_redirects=True) as client:
+            response = await client.get(pin.image_url, timeout=20)
+            response.raise_for_status()
+
+        mime_type = response.headers.get("content-type", "image/jpeg").split(";", 1)[0]
+        image_part = {
+            "mime_type": mime_type if mime_type.startswith("image/") else "image/jpeg",
+            "data": response.content,
+        }
+
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel("gemini-2.0-flash")
+        gemini_response = await asyncio.to_thread(model.generate_content, [_VISION_PROMPT, image_part])
+
+        text = _response_text(gemini_response)
+        if not text:
+            logger.warning("Empty Gemini response for pin %s", pin.id)
+            return {}
+
+        payload = _extract_json(text)
+        if not payload:
+            logger.warning("Unable to parse Gemini JSON for pin %s", pin.id)
+            return {}
+
+        return _normalize_payload(payload)
+    except Exception as exc:
+        logger.warning("Vision analysis failed for pin %s: %s", pin.id, exc)
+        return {}
+
+
+def _apply_vision_metadata(pin: Pin, vision: dict[str, Any]) -> None:
+    """Persist normalized vision fields into pin.extra."""
+    pin.extra["vision_description"] = str(vision.get("description", "")).strip()
+    pin.extra["vision_tags"] = _string_list(vision.get("tags"))
+    pin.extra["vision_colors"] = _string_list(vision.get("dominant_colors"))
+    pin.extra["vision_style"] = _string_list(vision.get("style_keywords"))
+    pin.extra["vision_mood"] = str(vision.get("mood", "")).strip()
+
+
+async def analyze_pins(pins: list[Pin], api_key: str, concurrency: int = 5) -> None:
+    """Analyze pins in parallel and mutate each pin with vision metadata."""
+    if concurrency <= 0:
+        concurrency = 1
+
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _analyze_one(pin: Pin) -> None:
+        async with sem:
+            vision = await analyze_pin(pin, api_key)
+            _apply_vision_metadata(pin, vision)
+
+    await asyncio.gather(*[_analyze_one(pin) for pin in pins])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "jinja2",
     "click",
     "rich",
+    "google-generativeai",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -70,3 +70,24 @@ def test_export_markdown_no_title_fallback(tmp_path):
 
     content = out.read_text()
     assert "(no title)" in content
+
+
+def test_export_markdown_includes_vision_metadata(tmp_path):
+    pins = _make_pins()
+    pins[0].extra = {
+        "vision_description": "A cozy vintage chair in warm daylight.",
+        "vision_tags": ["vintage", "chair", "cozy"],
+        "vision_colors": ["#A67C52", "#F5EBDD"],
+        "vision_style": ["rustic", "classic"],
+        "vision_mood": "warm",
+    }
+
+    out = tmp_path / "board.md"
+    export_markdown(pins, "https://www.pinterest.com/user/board/", out)
+
+    content = out.read_text()
+    assert "Vision description" in content
+    assert "vintage, chair, cozy" in content
+    assert "#A67C52, #F5EBDD" in content
+    assert "rustic, classic" in content
+    assert "Vision mood:** warm" in content

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,0 +1,114 @@
+"""Tests for pinterest_export.vision."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pinterest_export.models import Pin
+from pinterest_export.vision import analyze_pin, analyze_pins
+
+
+def _make_pin(id_: str = "1") -> Pin:
+    return Pin(
+        id=id_,
+        image_url="https://i.pinimg.com/originals/ab/cd/ef.jpg",
+        title="Test pin",
+        description="",
+        link=f"https://www.pinterest.com/pin/{id_}/",
+        board_url="https://www.pinterest.com/user/board/",
+    )
+
+
+@pytest.mark.asyncio
+async def test_analyze_pin_returns_normalized_payload():
+    pin = _make_pin()
+
+    fake_http_response = MagicMock()
+    fake_http_response.raise_for_status = MagicMock()
+    fake_http_response.content = b"fake-image-bytes"
+    fake_http_response.headers = {"content-type": "image/jpeg"}
+
+    class FakeModel:
+        def generate_content(self, parts):
+            assert parts
+            return SimpleNamespace(
+                text=(
+                    '{"description":"A wooden chair","tags":["chair","wood"],'
+                    '"dominant_colors":["#A67C52"],"style_keywords":["rustic"],'
+                    '"mood":"cozy"}'
+                )
+            )
+
+    fake_genai = SimpleNamespace(
+        configure=MagicMock(),
+        GenerativeModel=MagicMock(return_value=FakeModel()),
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_cls, patch("pinterest_export.vision.genai", fake_genai):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(return_value=fake_http_response)
+        mock_client_cls.return_value = mock_client
+
+        result = await analyze_pin(pin, api_key="test-key")
+
+    assert result["description"] == "A wooden chair"
+    assert result["tags"] == ["chair", "wood"]
+    assert result["dominant_colors"] == ["#A67C52"]
+    assert result["style_keywords"] == ["rustic"]
+    assert result["mood"] == "cozy"
+
+
+@pytest.mark.asyncio
+async def test_analyze_pin_returns_empty_dict_on_http_error():
+    pin = _make_pin()
+
+    fake_genai = SimpleNamespace(
+        configure=MagicMock(),
+        GenerativeModel=MagicMock(),
+    )
+
+    with patch("httpx.AsyncClient") as mock_client_cls, patch("pinterest_export.vision.genai", fake_genai):
+        mock_client = AsyncMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.get = AsyncMock(side_effect=RuntimeError("boom"))
+        mock_client_cls.return_value = mock_client
+
+        result = await analyze_pin(pin, api_key="test-key")
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_analyze_pins_mutates_pin_extra_fields():
+    pins = [_make_pin("1"), _make_pin("2")]
+
+    responses = [
+        {
+            "description": "First",
+            "tags": ["one"],
+            "dominant_colors": ["#111111"],
+            "style_keywords": ["modern"],
+            "mood": "calm",
+        },
+        {},
+    ]
+
+    mock_analyze_pin = AsyncMock(side_effect=responses)
+    with patch("pinterest_export.vision.analyze_pin", mock_analyze_pin):
+        await analyze_pins(pins, api_key="test-key", concurrency=2)
+
+    assert pins[0].extra["vision_description"] == "First"
+    assert pins[0].extra["vision_tags"] == ["one"]
+    assert pins[0].extra["vision_colors"] == ["#111111"]
+    assert pins[0].extra["vision_style"] == ["modern"]
+    assert pins[0].extra["vision_mood"] == "calm"
+
+    assert pins[1].extra["vision_description"] == ""
+    assert pins[1].extra["vision_tags"] == []
+    assert pins[1].extra["vision_colors"] == []
+    assert pins[1].extra["vision_style"] == []
+    assert pins[1].extra["vision_mood"] == ""


### PR DESCRIPTION
## Summary

Implements GitHub Issue #5: Vision AI analysis per pin.

### What's new
- `--vision` flag to enable Gemini Flash 2.0 analysis on scraped pins
- Each pin gets: description, 5-10 tags, dominant colors, style keywords, mood
- Async batch processing with configurable concurrency (default: 5 parallel)
- Results stored in pin metadata and exported to JSON/Markdown
- Graceful error handling — failures are logged, never fatal

### Usage
```bash
pinterest-export https://pinterest.com/user/board --vision
pinterest-export https://pinterest.com/user/board --vision --vision-concurrency 10
```

### New fields in board.json / board.md
```json
{
  "vision_description": "A minimalist living room with warm afternoon light",
  "vision_tags": ["minimalist", "nordic", "interior", "warm"],
  "vision_colors": ["#FFFFFF", "#F5F0E8", "#C4A882"],
  "vision_style": ["scandinavian", "clean", "airy"],
  "vision_mood": "calm"
}
```

### Tests
- `tests/test_vision.py` — 3 new async tests (mocked Gemini + httpx)
- `tests/test_exporter.py` — 1 new test for Markdown vision metadata rendering
- 35 tests total, all passing

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered Vision analysis for pins using Gemini Flash
  * New `--vision` flag to enable analysis and `--vision-concurrency` to control processing speed
  * Analyzed pins now include AI-generated insights: descriptions, tags, colors, style, and mood metadata in exports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->